### PR TITLE
Simple case for url routing

### DIFF
--- a/src/cljs/sample_routing/colors.cljs
+++ b/src/cljs/sample_routing/colors.cljs
@@ -70,11 +70,10 @@
               ;; This is a trivial example that of course should be done purely in CSS
               ;; I just needed a basic case to demonstrate that local state works 
               :on-mouse-enter #(om/set-state! this {:selected? true})
-              :on-mouse-leave #(om/set-state! this {:selected? false})
-              :on-click #(c/set-route! this :route.colors/color {:queue? true
-                                                                 :params {:route-params {:color-id (str color-id)}}})}
+              :on-mouse-leave #(om/set-state! this {:selected? false})}
              [:td color-id]
-             [:td name]]))))
+             [:td
+              [:a {:href (str "/color/" color-id)} name]]]))))
 
 (def color-item-ui (om/factory ColorItem))
 

--- a/src/cljs/sample_routing/menu.cljs
+++ b/src/cljs/sample_routing/menu.cljs
@@ -1,8 +1,8 @@
 (ns sample-routing.menu
-  (:require [om.next :as om :refer-macros [defui]]
+  (:require [compassus.core :as c]
+            [om.next :as om :refer-macros [defui]]
             [sablono.core :refer-macros [html]]
-            [taoensso.timbre :as log]
-            [compassus.core :as c]))
+            [taoensso.timbre :as log]))
 
 (defui MenuItem
   static om/Ident
@@ -11,20 +11,19 @@
 
   static om/IQuery
   (query [_]
-    '[:id :title :route])
+    '[:id :title :route :url])
 
   Object
   (componentWillReceiveProps [this next-props]
     (om/set-state! this {:active (-> this c/current-route name)}))
 
   (render [this]
-    (let [{:keys [title id route]} (om/props this)
+    (let [{:keys [title id route url]} (om/props this)
           active?            (= (or (-> this om/get-state :active)
                                     (-> this c/current-route name)) title)]
       (html [:li {:key      id
                   :class    (if active? "active" "")}
-             [:div {:on-click (fn [e] (c/set-route! this route))}
-              title]]))))
+             [:a {:href url} title]]))))
 
 (def item (om/factory MenuItem))
 


### PR DESCRIPTION
**Simple case for url routing**

does not do backward propagation (when typed in address bar - doesn't render associated component)
